### PR TITLE
ADD: getip tool

### DIFF
--- a/getip/Makefile
+++ b/getip/Makefile
@@ -1,0 +1,11 @@
+CC=go
+SRC=getip.go
+BIN=getip
+
+.PHONY: all
+all:
+	$(CC) build -o $(BIN) $(SRC)
+
+.PHONY: clean
+clean:
+	rm -f $(BIN)

--- a/getip/README.md
+++ b/getip/README.md
@@ -1,0 +1,8 @@
+## getip
+Get your current public IP address on the cli.
+
+```
+getip usage
+------------
+$ ./getip
+```

--- a/getip/getip.go
+++ b/getip/getip.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"fmt"
+	"strings"
+	"net/http"
+	"io/ioutil"
+)
+
+const url = "https://icanhazip.com"
+
+func die(function string, err error) {
+	fmt.Printf("[Erorr] %s - %s\n", function, err.Error())
+	os.Exit(1)
+}
+
+func get_ip() string {
+	resp, err := http.Get(url)
+	if err != nil {
+		die("Get", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		die("ReadAll", err)
+	}
+
+	ip := strings.Trim(string(body), "\r\n")
+
+	return ip
+}
+
+func main() {
+	fmt.Printf("%s\n", get_ip())
+}


### PR DESCRIPTION
This PR adds the tool getip to the project.

* added getip tool which shows ones public IP
* added Makefile
* added README.md

Tested under Debian 11 (Bullseye) amd64 with Go 1.19
- go version go1.19.1 linux/amd64